### PR TITLE
Patch 1

### DIFF
--- a/synoBio/activate.sh
+++ b/synoBio/activate.sh
@@ -13,7 +13,7 @@ echo $DIR
 
 DIR=$(readlink -f $DIR)
 
-source ${DIR}/util.sh
+source ${DIR}/util.sh  ### this will add checkVars() and logRun() to environment.
 
 
 export ENVDIR=${DIR%/*}

--- a/synoBio/activate.sh
+++ b/synoBio/activate.sh
@@ -14,12 +14,12 @@ echo $DIR
 
 
 DIR=$(readlink -f $DIR)
-export ENVDIR=${DIR%/*}          ### this should be a "*/bin" directory
-export JARLIB=$ENVDIR/jar        ### "*/bin/jar"
+export ENVDIR=${DIR%/*}            ### this should be a "*/bin" directory
+export JARLIB=$ENVDIR/jar          ### "*/bin/jar"
 echo   Adding $ENVDIR to PATH
 
-source ${DIR}/util.sh            ### adding utilities like checkVars() and logRun() to environment.
-source /home/feng/.bash_profile  ### modify $PATH to add hisat2, bowtie2 and other binaries to path
+source ${DIR}/util.sh              ### adding utilities like checkVars() and logRun() to environment.
+# source /home/feng/.bash_profile  ### modify $PATH to add hisat2, bowtie2 and other binaries to path
 export PATH="$PATH:$DIR:$ENVDIR"
 ##### add more lines to specify paths for binaries
 

--- a/synoBio/activate.sh
+++ b/synoBio/activate.sh
@@ -4,21 +4,27 @@ called=$_
 [[ $called != $0 ]] && echo "Script is being sourced" || echo "Script is being run"
 echo "\$BASH_SOURCE ${BASH_SOURCE[0]}"
 # echo "\$BASH_SOURCE ${BASH_SOURCE[*]}"
-source /etc/profile
-source /home/feng/.bash_profile
+source /etc/profile  
+
+
+
 DIR=${BASH_SOURCE[0]%/*}
 
 echo $DIR
 
 
 DIR=$(readlink -f $DIR)
+export ENVDIR=${DIR%/*}          ### this should be a "*/bin" directory
+export JARLIB=$ENVDIR/jar        ### "*/bin/jar"
+echo   Adding $ENVDIR to PATH
 
-source ${DIR}/util.sh  ### this will add checkVars() and logRun() to environment.
-
-
-export ENVDIR=${DIR%/*}
-export JARLIB=$ENVDIR/jar
-mkdir -p $JARLIB
-echo Adding $ENVDIR to PATH
+source ${DIR}/util.sh            ### adding utilities like checkVars() and logRun() to environment.
+source /home/feng/.bash_profile  ### modify $PATH to add hisat2, bowtie2 and other binaries to path
 export PATH="$PATH:$DIR:$ENVDIR"
+##### add more lines to specify paths for binaries
 
+{
+  which hisat2 || echo hisat2 not found
+  which bowtie2 || echo bowtie2 not found
+  #which trimmomatic  || echo trimmomatic not found
+}

--- a/synoBio/init.sh
+++ b/synoBio/init.sh
@@ -62,12 +62,15 @@ echo ---- Installing binaries
 # ############################################
 
 
-ORIGIN=`readlink -f ${SELF%/*}`
-cp -u $ORIGIN/activate.sh bin/activate
-cp -u $ORIGIN/*.sh bin/
-cp -u $ORIGIN/checkVars bin/ # line added by Birte 04-2020
-cp -u $ORIGIN/logRun bin/ # line added by Birte 04-2020
-cp -uR $ORIGIN/config config
+ORIGIN=`readlink -f ${SELF%/*}` 
+cp -prf $ORIGIN/* -t $PWD/bin ### Feng: copy everything into bin
+cp -pf $PWD/bin/activate.sh $PWD/bin/activate ### Feng: not essential
+chmod +x $PWD/bin/*
+# cp -u $ORIGIN/activate.sh bin/activate
+# cp -u $ORIGIN/*.sh bin/
+# cp -u $ORIGIN/checkVars bin/ # line added by Birte 04-2020
+# cp -u $ORIGIN/logRun bin/ # line added by Birte 04-2020
+# cp -uR $ORIGIN/config config
 echo export ORIGIN=$ORIGIN >> bin/activate
 
 

--- a/synoBio/pipeline_mapper.sh
+++ b/synoBio/pipeline_mapper.sh
@@ -91,7 +91,7 @@ main()
         #### echo ==== Running pipeline    
         cd $TEMPDIR
         ls -lh .
-        read OLDDIR < OLDDIR
+        # read OLDDIR < OLDDIR
         read FILEARG < FILEARG
         local CMD="$PROG -t $NCORE $FILEARG"
         echo [CMD]$CMD
@@ -103,17 +103,13 @@ main()
 
     {
         #### echo ==== Uploading outputs
-        OUTALI=${PROG%.*}/$OLDDIR
-
+        # OUTALI=${PROG%.*}/$OLDDIR
         INDIR=$PWD
-        uploadOutput.sh $INDIR $OUTDIR/${PROG%.*}
-#         read OUTALI< $INDIR/DATAACC
-#         mkdir -p $OUTDIR/$OUTALI
-# #         cp output/* $OUTDIR/$OUTALI
-#         cpLink output/* $OUTDIR/$OUTALI
+        ODIR=$OUTDIR/${PROG%.*}
+        uploadOutput.sh $INDIR $ODIR
+        echo "[FINISH]: Outputed to $ODIR"
     }  
     cd ..
-    echo "[FINISH]: Outputed to $OUTDIR/$OUTALI"
     
     #### Cache the scripts
     if [[ -n "$ORIGIN" ]]; then


### PR DESCRIPTION

1. activate.sh: sources /home/feng/.bash_profile. I looked into it, you specified some paths. Do I need that script/my own version of the script? 
Feng: I think these paths are only essential for binaries. I have included a copy in shouldsee/slcu-server-static. It's best if you make the pipeline work without this line.

2. pipeline_mapper.sh: line 94 and 95, where are OLDDIR and FILEARG variables specified? I get an error OLDDIR not found.
2a. (uploadOutput.sh: same as in 2., line 5, where does DATAACC come from?).
Feng: OLDDIR was an variable read from a file named "OLDDIR",etc. OLDDIR is deprecated and I have modified the script in PR accordingly.

3. init.sh: line 67, only *.sh scripts are copied, what about the relevant .py scripts? 
I also found that of course checkVars and logRun are not copied, although called in several scripts. I solved it by adding lines in init.sh for them. (I could do the same for *.py, of course, but I wondered how you called .py/checkVars/logRun with that existing code in init.sh.)
Feng: I have modified init.sh in PR accordingly
